### PR TITLE
Add share button to teambuilder

### DIFF
--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
     <script src="{% static 'bootstrap/js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'jQuery-MultiSelect-master/jquery.multiselect.js' %}"></script>
-    <script src="{% static 'js/index.js' %}"></script>
     <script src="{% static 'js/shared.js' %}"></script>
+    <script src="{% static 'js/index.js' %}"></script>
 
 </head>
 <html>  
@@ -203,7 +203,7 @@
                   </button>
                 </div>  
                 <hr>
-                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="createAndCopyShareLink()">Copy Query Link to Clipboard</a></div>
+                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="createAndCopyShareLinkIndex()">Copy Query Link to Clipboard</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/speedcalc">Speed Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/switchincalc">Switch Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="sendToTeamBuilder()">Team Builder</a></div>               
@@ -621,8 +621,8 @@
 
 
      <script>
-      
-      document.body.style.zoom="70%"    
+
+      document.body.style.zoom="70%"
       
       $('select[multiple]').multiselect({
         columns: 1,

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
     <script src="{% static 'bootstrap/js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'jQuery-MultiSelect-master/jquery.multiselect.js' %}"></script>
-    <script src="{% static 'js/teambuilder.js' %}"></script>
     <script src="{% static 'js/shared.js' %}"></script>
+    <script src="{% static 'js/teambuilder.js' %}"></script>
 
     
 </head>
@@ -142,6 +142,9 @@
                     </div>
                     <hr>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
+                      <a href="javascript:void(0);" onclick="createAndCopyShareLink(null, true)">Copy Query Link to Clipboard</a>
+                    </div>
+                    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
                       <a href="javascript:void(0);" onclick="sendToCalc()">Back to main Buddy</a>
                   </div>                  
                 </div>
@@ -171,7 +174,13 @@
           if (urlParams.size == 0){
             return;
           }
-          setFormFromParams(urlParams);          
+          setFormFromParams(urlParams);
+
+          const calc = urlParams.get('Calc');
+          if (calc == 1) {
+              document.getElementById('postaction').submit();
+          }
+
 
           });
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -126,37 +126,21 @@ function sendToTeamBuilder() {
     window.open(url, '_blank').focus();
 }
 
-async function createAndCopyShareLink() {
-    const params = new URLSearchParams();
-    const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
-
-
-    formElements.forEach(element => {
-        if (element.type === 'checkbox') {
-            params.append(element.name, element.checked ? 'on' : 'off');
-        }
-        else {
-            params.append(element.name, element.value);
-        }
-    });
-
+function getSetsParams(){
+    const setsParams = new URLSearchParams();
     convertToPost('Set1')
     convertToPost('Set2')
     convertToPost('Set3')
 
-    params.append('Set1', document.getElementById('Set1').value);
-    params.append('Set2', document.getElementById('Set2').value);
-    params.append('Set3', document.getElementById('Set3').value);
+    setsParams.append('Set1', document.getElementById('Set1').value);
+    setsParams.append('Set2', document.getElementById('Set2').value);
+    setsParams.append('Set3', document.getElementById('Set3').value);
 
-    params.append('Calc', 1);
+    return setsParams;
 
-    const url = `${window.location.protocol}//${window.location.host}/?${params.toString()}`;
-    try {
-        await navigator.clipboard.writeText(url);
-    } catch (error) {
-        console.error(error.message);
-    }
 }
+
+
 
 function updateIndexFromParams(urlParams) {
 
@@ -185,4 +169,9 @@ function updateIndexFromParams(urlParams) {
         document.getElementById('postaction').submit();
         document.getElementById('Calcbar').hidden = false;
     }
+}
+
+async function createAndCopyShareLinkIndex(){
+    const setsParams = getSetsParams();
+    await createAndCopyShareLink(setsParams);
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -14,3 +14,37 @@ function setFormFromParams(urlParams) {
     }
   });
 }
+
+async function createAndCopyShareLink(initialParams = null, includePathName = false) {
+    let params = new URLSearchParams();
+
+    if (initialParams){
+        params = initialParams;
+    }
+
+    const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
+
+
+    formElements.forEach(element => {
+        if (element.type === 'checkbox') {
+            params.append(element.name, element.checked ? 'on' : 'off');
+        }
+        else {
+            params.append(element.name, element.value);
+        }
+    });
+
+    params.append('Calc', 1);
+
+    let pathname = "/";
+    if (includePathName){
+      pathname = `${window.location.pathname}`
+    }
+
+    const url = `${window.location.protocol}//${window.location.host}${pathname}?${params.toString()}`;
+    try {
+        await navigator.clipboard.writeText(url);
+    } catch (error) {
+        console.error(error.message);
+    }
+}


### PR DESCRIPTION
- Adds the **Copy Query Link to Clipboard** button to the teambuilder.
- Refactors index to use a wrapped method which adds the sets to the query before passing to the shared `createAndCopyShareLink` function.  
- Adds two optional parameters to `createAndCopyShareLink`, `initialParams` - i.e. page specific params, & `includePathName` for any pages other than `/`