### PR TITLE
Add checkbox for selected team members, & share to teambuilder page

### DIFF
--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
@@ -188,7 +188,7 @@
                   </button>
                 </div>  
                 <hr>
-                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="createAndCopyShareLink()">Copy Query Link to Clipboard</a></div>
+                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="createAndCopyShareLinkIndex()">Copy Query Link to Clipboard</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/speedcalc">Speed Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/switchincalc">Switch Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="sendToTeamBuilder()">Team Builder</a></div>               

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/index.html
@@ -188,7 +188,7 @@
                   </button>
                 </div>  
                 <hr>
-                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="createAndCopyShareLinkIndex()">Copy Query Link to Clipboard</a></div>
+                <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a id="createAndCopyShareLink" href="javascript:void(0);" onclick="createAndCopyShareLinkIndex()">Copy Query Link to Clipboard</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/speedcalc">Speed Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="/switchincalc">Switch Calculator</a></div>
                 <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1"><a href="javascript:void(0);" onclick="sendToTeamBuilder()">Team Builder</a></div>               

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -8,8 +8,8 @@
     <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
     <script src="{% static 'bootstrap/js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'jQuery-MultiSelect-master/jquery.multiselect.js' %}"></script>
-    <script src="{% static 'js/teambuilder.js' %}"></script>
     <script src="{% static 'js/shared.js' %}"></script>
+    <script src="{% static 'js/teambuilder.js' %}"></script>
 
     
 </head>
@@ -142,6 +142,9 @@
                     </div>
                     <hr>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
+                      <a href="javascript:void(0);" onclick="createAndCopyShareLink(null, true)">Copy Query Link to Clipboard</a>
+                    </div>
+                    <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
                       <a href="javascript:void(0);" onclick="sendToCalc()">Back to main Buddy</a>
                   </div>                  
                 </div>
@@ -171,7 +174,13 @@
           if (urlParams.size == 0){
             return;
           }
-          setFormFromParams(urlParams);          
+          setFormFromParams(urlParams);
+
+          const calc = urlParams.get('Calc');
+          if (calc == 1) {
+              document.getElementById('postaction').submit();
+          }
+
 
           });
 

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -191,9 +191,6 @@
         <script>
           document.body.style.zoom="70%"
 
-          // Variable to store state of checkboxes
-          let teamChecked = [];
-
           document.addEventListener('DOMContentLoaded', function() {
           const urlParams = new URLSearchParams(window.location.search);
             
@@ -229,16 +226,6 @@
                 document.getElementById('Level').value = '{{Level}}';
                 document.getElementById('Round').value = '{{Round}}';
                 if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}
-                {% if set1Check %} teamChecked.push("set1Check"); {% endif %}
-                {% if set2Check %} teamChecked.push("set2Check"); {% endif %}
-                {% if set3Check %} teamChecked.push("set3Check"); {% endif %}
-                {% if set4Check %} teamChecked.push("set4Check"); {% endif %}
-                {% if set5Check %} teamChecked.push("set5Check"); {% endif %}
-                {% if set6Check %} teamChecked.push("set6Check"); {% endif %}
-
-                for (var i = 0; i < teamChecked.length; i++) {
-                    $("#" + teamChecked[i]).prop("checked", true);
-                }
 
                 highlightMatchingTeamMembers();
 

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -165,7 +165,7 @@
                     </div>
                     <hr>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
-                      <a href="javascript:void(0);" onclick="createAndCopyShareLink(null, true)">Copy Query Link to Clipboard</a>
+                      <a id="createAndCopyShareLink" href="javascript:void(0);" onclick="createAndCopyShareLink(null, true)">Copy Query Link to Clipboard</a>
                     </div>
                     <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
                       <a href="javascript:void(0);" onclick="sendToCalc()">Back to main Buddy</a>

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -10,7 +10,12 @@
     <script src="{% static 'jQuery-MultiSelect-master/jquery.multiselect.js' %}"></script>
     <script src="{% static 'js/shared.js' %}"></script>
     <script src="{% static 'js/teambuilder.js' %}"></script>
-
+    <style>
+        .accordion-header.highlight .accordion-button {
+            background-color: rgba(13, 204, 242, 0.2);
+            color: black;
+        }
+    </style>
     
 </head>
 <html>  
@@ -184,7 +189,10 @@
         
        </main>  
         <script>
-          document.body.style.zoom="70%"    
+          document.body.style.zoom="70%"
+
+          // Variable to store state of checkboxes
+          let teamChecked = [];
 
           document.addEventListener('DOMContentLoaded', function() {
           const urlParams = new URLSearchParams(window.location.search);
@@ -221,7 +229,19 @@
                 document.getElementById('Level').value = '{{Level}}';
                 document.getElementById('Round').value = '{{Round}}';
                 if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}
-                if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}
+                {% if set1Check %} teamChecked.push("set1Check"); {% endif %}
+                {% if set2Check %} teamChecked.push("set2Check"); {% endif %}
+                {% if set3Check %} teamChecked.push("set3Check"); {% endif %}
+                {% if set4Check %} teamChecked.push("set4Check"); {% endif %}
+                {% if set5Check %} teamChecked.push("set5Check"); {% endif %}
+                {% if set6Check %} teamChecked.push("set6Check"); {% endif %}
+
+                for (var i = 0; i < teamChecked.length; i++) {
+                    $("#" + teamChecked[i]).prop("checked", true);
+                }
+
+                highlightMatchingTeamMembers();
+
 
             }
             else 

--- a/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
+++ b/BattleFactoryBuddy/templates/BattleFactoryBuddy/teambuilder.html
@@ -69,6 +69,9 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 1 Team Member Check" type="checkbox" name="set1Check" id="set1Check" {% if set1Check %}checked{% endif %}>
+                              </div>
                           </div>
                           <div class="set-title">Set 2</div>
                           <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
@@ -81,6 +84,9 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 2 Team Member Check" type="checkbox" id="set2Check" name="set2Check" {% if set2Check %}checked{% endif %}>
+                              </div>
                           </div>
                           <div class="set-title">Set 3</div>
                           <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
@@ -93,6 +99,9 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 3 Team Member Check" type="checkbox" name="set3Check" id="set3Check" {% if set3Check %}checked{% endif %}>
+                              </div>
                           </div>
                           <h5 class="card-title" id="OpponentsHeader">Last Opponents</h5>
                           <div class="set-title">Set 4</div>
@@ -106,6 +115,9 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 4 Team Member Check" type="checkbox" id="set4Check" name="set4Check" {% if set4Check %}checked{% endif %}>
+                              </div>
                           </div>
                           <div class="set-title">Set 5</div>
                           <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
@@ -118,6 +130,9 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 5 Team Member Check" type="checkbox" name="set5Check" id="set5Check" {% if set5Check %}checked{% endif %}>
+                              </div>
                           </div>
                           <div class="set-title">Set 6</div>
                           <div class="d-grid gap-2 d-sm-flex justify-content-sm-center align-items-center my-1">
@@ -130,7 +145,10 @@
                               <option value="15">15 IVs</option>        
                               <option value="31">31 IVs</option>                              
                             </select>
-                                      </div>
+                              <div class="form-check">
+                                  <input class="form-check-input team-checkbox" aria-label="Set 6 Team Member Check" type="checkbox" name="set6Check" id="set6Check" {% if set6Check %}checked{% endif %}>
+                              </div>
+                          </div>
                           
                         </div>
                     </div>
@@ -202,7 +220,9 @@
                 document.getElementById('set6IVs').value = '{{set6IVs}}';
                 document.getElementById('Level').value = '{{Level}}';
                 document.getElementById('Round').value = '{{Round}}';
-                if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}    
+                if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}
+                if ('{{SwapMode}}' == "on"){document.getElementById('SwapMode').checked = true;}
+
             }
             else 
             {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -116,37 +116,21 @@ function sendToTeamBuilder() {
     window.open(url, '_blank').focus();
 }
 
-async function createAndCopyShareLink() {
-    const params = new URLSearchParams();
-    const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
-
-
-    formElements.forEach(element => {
-        if (element.type === 'checkbox') {
-            params.append(element.name, element.checked ? 'on' : 'off');
-        }
-        else {
-            params.append(element.name, element.value);
-        }
-    });
-
+function getSetsParams(){
+    const setsParams = new URLSearchParams();
     convertToPost('Set1')
     convertToPost('Set2')
     convertToPost('Set3')
 
-    params.append('Set1', document.getElementById('Set1').value);
-    params.append('Set2', document.getElementById('Set2').value);
-    params.append('Set3', document.getElementById('Set3').value);
+    setsParams.append('Set1', document.getElementById('Set1').value);
+    setsParams.append('Set2', document.getElementById('Set2').value);
+    setsParams.append('Set3', document.getElementById('Set3').value);
 
-    params.append('Calc', 1);
+    return setsParams;
 
-    const url = `${window.location.protocol}//${window.location.host}/?${params.toString()}`;
-    try {
-        await navigator.clipboard.writeText(url);
-    } catch (error) {
-        console.error(error.message);
-    }
 }
+
+
 
 function updateIndexFromParams(urlParams) {
 
@@ -173,4 +157,9 @@ function updateIndexFromParams(urlParams) {
         document.getElementById('postaction').submit();
         document.getElementById('Calcbar').hidden = false;
     }
+}
+
+async function createAndCopyShareLinkIndex(){
+    const setsParams = getSetsParams();
+    await createAndCopyShareLink(setsParams);
 }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -14,3 +14,37 @@ function setFormFromParams(urlParams) {
     }
   });
 }
+
+async function createAndCopyShareLink(initialParams = null, includePathName = false) {
+    let params = new URLSearchParams();
+
+    if (initialParams){
+        params = initialParams;
+    }
+
+    const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
+
+
+    formElements.forEach(element => {
+        if (element.type === 'checkbox') {
+            params.append(element.name, element.checked ? 'on' : 'off');
+        }
+        else {
+            params.append(element.name, element.value);
+        }
+    });
+
+    params.append('Calc', 1);
+
+    let pathname = "/";
+    if (includePathName){
+      pathname = `${window.location.pathname}`
+    }
+
+    const url = `${window.location.protocol}//${window.location.host}${pathname}?${params.toString()}`;
+    try {
+        await navigator.clipboard.writeText(url);
+    } catch (error) {
+        console.error(error.message);
+    }
+}

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -42,8 +42,16 @@ async function createAndCopyShareLink(initialParams = null, includePathName = fa
     }
 
     const url = `${window.location.protocol}//${window.location.host}${pathname}?${params.toString()}`;
+
+  const copyElement = document.getElementById('createAndCopyShareLink');
+  const priorText = copyElement.textContent;
+
     try {
         await navigator.clipboard.writeText(url);
+    copyElement.textContent = "Copied";
+    setTimeout(() => {
+      copyElement.textContent = priorText;
+    }, 1500);
     } catch (error) {
         console.error(error.message);
     }

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -45,10 +45,13 @@ async function createAndCopyShareLink(initialParams = null, includePathName = fa
 
   const copyElement = document.getElementById('createAndCopyShareLink');
   const priorText = copyElement.textContent;
+  const copiedSuccText = "Copied";
 
   try {
     await navigator.clipboard.writeText(url);
-    copyElement.textContent = "Copied";
+    // Cover clicked while Copied is shown case
+    if(copyElement.textContent == copiedSuccText) return;
+    copyElement.textContent = copiedSuccText;
     setTimeout(() => {
       copyElement.textContent = priorText;
     }, 1500);

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -16,43 +16,43 @@ function setFormFromParams(urlParams) {
 }
 
 async function createAndCopyShareLink(initialParams = null, includePathName = false) {
-    let params = new URLSearchParams();
+  let params = new URLSearchParams();
 
-    if (initialParams){
-        params = initialParams;
+  if (initialParams) {
+    params = initialParams;
+  }
+
+  const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
+
+
+  formElements.forEach(element => {
+    if (element.type === 'checkbox') {
+      params.append(element.name, element.checked ? 'on' : 'off');
     }
-
-    const formElements = document.querySelectorAll('.form-select, .form-check-input, .form-control');
-
-
-    formElements.forEach(element => {
-        if (element.type === 'checkbox') {
-            params.append(element.name, element.checked ? 'on' : 'off');
-        }
-        else {
-            params.append(element.name, element.value);
-        }
-    });
-
-    params.append('Calc', 1);
-
-    let pathname = "/";
-    if (includePathName){
-      pathname = `${window.location.pathname}`
+    else {
+      params.append(element.name, element.value);
     }
+  });
 
-    const url = `${window.location.protocol}//${window.location.host}${pathname}?${params.toString()}`;
+  params.append('Calc', 1);
+
+  let pathname = "/";
+  if (includePathName) {
+    pathname = `${window.location.pathname}`
+  }
+
+  const url = `${window.location.protocol}//${window.location.host}${pathname}?${params.toString()}`;
 
   const copyElement = document.getElementById('createAndCopyShareLink');
   const priorText = copyElement.textContent;
 
-    try {
-        await navigator.clipboard.writeText(url);
+  try {
+    await navigator.clipboard.writeText(url);
     copyElement.textContent = "Copied";
     setTimeout(() => {
       copyElement.textContent = priorText;
     }, 1500);
-    } catch (error) {
-        console.error(error.message);
-    }
+  } catch (error) {
+    console.error(error.message);
+  }
 }

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -97,19 +97,14 @@ function highlightMatchingTeamMembers() {
 
 $(document).ready(function() {
     $("input.team-checkbox").change(function () {
-        if ($(this).is(":checked")) {
-            teamChecked.push(this.id);
-            if (teamChecked.length > 3) {
-                teamChecked.splice(0, 1);
-            }
-            $("input.team-checkbox").prop("checked", false);
-            for (let i = 0; i < teamChecked.length; i++) {
-                $("#" + teamChecked[i]).prop("checked", true);
-            }
-        } else {
-            let index = teamChecked.indexOf(this.id);
-            teamChecked.splice(index, 1);
+        let maxChecked = 3;
+        let checkedChecks = document.querySelectorAll(".team-checkbox:checked");
+        if(checkedChecks.length >= maxChecked + 1)
+        {
+            this.checked = false;
+            return;
         }
+
         highlightMatchingTeamMembers();
     });
 });

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -23,17 +23,15 @@ function sendToCalc() {
         }
     });
 
-    // Add the remaining sets in order
-    sets.forEach((set, index) => {
-        const species = document.getElementById(set.id).value.split('-')[0];
-        if (!set.check) {
-            if (team.length < 3) {
-                team.push(species);
-            } else {
+    // Add the remaining sets in order, if a full team has been selected
+    if (team.length == 3) {
+        sets.forEach((set, index) => {
+            const species = document.getElementById(set.id).value.split('-')[0];
+            if (!set.check) {
                 lastOpp.push(species);
             }
-        }
-    });
+        });
+    }
 
     // Add the team members to the URL parameters
     if (team[0]) params.append('Team1', team[0]);

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -3,32 +3,47 @@ function sendToCalc() {
     params.append('Level', document.getElementById('Level').value);
     params.append('Round', document.getElementById('Round').value);
 
+    const sets = [
+        { id: 'set1', check: document.getElementById('set1Check').checked },
+        { id: 'set2', check: document.getElementById('set2Check').checked },
+        { id: 'set3', check: document.getElementById('set3Check').checked },
+        { id: 'set4', check: document.getElementById('set4Check').checked },
+        { id: 'set5', check: document.getElementById('set5Check').checked },
+        { id: 'set6', check: document.getElementById('set6Check').checked }
+    ];
 
-    const team1 = document.getElementById('set1').value.split('-')[0];
-    const team2 = document.getElementById('set2').value.split('-')[0];
-    const team3 = document.getElementById('set3').value.split('-')[0];
-    const lastOpp1 = document.getElementById('set4').value.split('-')[0];
-    const lastOpp2 = document.getElementById('set5').value.split('-')[0];
-    const lastOpp3 = document.getElementById('set6').value.split('-')[0];
+    const team = [];
+    const lastOpp = [];
 
-    if (team1) {
-        params.append('Team1', team1);
-    }
-    if (team2) {
-        params.append('Team2', team2);
-    }
-    if (team3) {
-        params.append('Team3', team3);
-    }
-    if (lastOpp1) {
-        params.append('LastOpp1', lastOpp1);
-    }
-    if (lastOpp2) {
-        params.append('LastOpp2', lastOpp2);
-    }
-    if (lastOpp3) {
-        params.append('LastOpp3', lastOpp3);
-    }
+    // Add our checked team
+    sets.forEach((set, index) => {
+        const mon = document.getElementById(set.id).value.split('-')[0];
+        if (set.check) {
+            team.push(mon);
+        }
+    });
+
+    // Add the remaining sets in order
+    sets.forEach((set, index) => {
+        const mon = document.getElementById(set.id).value.split('-')[0];
+        if (!set.check) {
+            if (team.length < 3) {
+                team.push(mon);
+            } else {
+                lastOpp.push(mon);
+            }
+        }
+    });
+
+    // Add the team members to the URL parameters
+    if (team[0]) params.append('Team1', team[0]);
+    if (team[1]) params.append('Team2', team[1]);
+    if (team[2]) params.append('Team3', team[2]);
+
+    // Add the last opponents to the URL parameters
+    if (lastOpp[0]) params.append('LastOpp1', lastOpp[0]);
+    if (lastOpp[1]) params.append('LastOpp2', lastOpp[1]);
+    if (lastOpp[2]) params.append('LastOpp3', lastOpp[2]);
 
     const url = `/?${params.toString()}`;
     window.location.href = url;

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -15,22 +15,22 @@ function sendToCalc() {
     const team = [];
     const lastOpp = [];
 
-    // Add our checked team
+    // Add the checked team members
     sets.forEach((set, index) => {
-        const mon = document.getElementById(set.id).value.split('-')[0];
+        const species = document.getElementById(set.id).value.split('-')[0];
         if (set.check) {
-            team.push(mon);
+            team.push(species);
         }
     });
 
     // Add the remaining sets in order
     sets.forEach((set, index) => {
-        const mon = document.getElementById(set.id).value.split('-')[0];
+        const species = document.getElementById(set.id).value.split('-')[0];
         if (!set.check) {
             if (team.length < 3) {
-                team.push(mon);
+                team.push(species);
             } else {
-                lastOpp.push(mon);
+                lastOpp.push(species);
             }
         }
     });
@@ -70,7 +70,7 @@ function showhideSwitch() {
 }
 
 function highlightMatchingTeamMembers() {
-    // Build the checklist array from the selected items
+    // Build the array of checked sets
     let checklist = [];
     if ($('#set1Check').is(":checked")) checklist.push($('#set1').val());
     if ($('#set2Check').is(":checked")) checklist.push($('#set2').val());
@@ -84,6 +84,8 @@ function highlightMatchingTeamMembers() {
         let headerText = $(this).text();
 
         // Can do === 3 for all only
+        // Highlight any team headers which contain all of the checked members
+        // i.e 1 team if all checked, or 4 if two checked...
         let containsAll = checklist.length >= 1 && checklist.every(function(item) {
             return headerText.includes(item);
         });
@@ -96,6 +98,7 @@ function highlightMatchingTeamMembers() {
 }
 
 $(document).ready(function() {
+    // Only allow 3 checkboxes (the team) to be checked
     $("input.team-checkbox").change(function () {
         let maxChecked = 3;
         let checkedChecks = document.querySelectorAll(".team-checkbox:checked");

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -53,3 +53,48 @@ function showhideSwitch() {
         }
     }
 }
+
+function highlightMatchingTeamMembers() {
+    // Build the checklist array from the selected items
+    let checklist = [];
+    if ($('#set1Check').is(":checked")) checklist.push($('#set1').val());
+    if ($('#set2Check').is(":checked")) checklist.push($('#set2').val());
+    if ($('#set3Check').is(":checked")) checklist.push($('#set3').val());
+    if ($('#set4Check').is(":checked")) checklist.push($('#set4').val());
+    if ($('#set5Check').is(":checked")) checklist.push($('#set5').val());
+    if ($('#set6Check').is(":checked")) checklist.push($('#set6').val());
+
+    // Highlight matching items in the accordion headers
+    $('.accordion-header').each(function() {
+        let headerText = $(this).text();
+
+        // Can do === 3 for all only
+        let containsAll = checklist.length >= 1 && checklist.every(function(item) {
+            return headerText.includes(item);
+        });
+        if (containsAll) {
+            $(this).addClass('highlight');
+        } else {
+            $(this).removeClass('highlight');
+        }
+    });
+}
+
+$(document).ready(function() {
+    $("input.team-checkbox").change(function () {
+        if ($(this).is(":checked")) {
+            teamChecked.push(this.id);
+            if (teamChecked.length > 3) {
+                teamChecked.splice(0, 1);
+            }
+            $("input.team-checkbox").prop("checked", false);
+            for (let i = 0; i < teamChecked.length; i++) {
+                $("#" + teamChecked[i]).prop("checked", true);
+            }
+        } else {
+            let index = teamChecked.indexOf(this.id);
+            teamChecked.splice(index, 1);
+        }
+        highlightMatchingTeamMembers();
+    });
+});

--- a/static/js/teambuilder.js
+++ b/static/js/teambuilder.js
@@ -78,13 +78,13 @@ function highlightMatchingTeamMembers() {
     if ($('#set6Check').is(":checked")) checklist.push($('#set6').val());
 
     // Highlight matching items in the accordion headers
-    $('.accordion-header').each(function() {
+    $('.accordion-header').each(function () {
         let headerText = $(this).text();
 
         // Can do === 3 for all only
         // Highlight any team headers which contain all of the checked members
         // i.e 1 team if all checked, or 4 if two checked...
-        let containsAll = checklist.length >= 1 && checklist.every(function(item) {
+        let containsAll = checklist.length >= 1 && checklist.every(function (item) {
             return headerText.includes(item);
         });
         if (containsAll) {
@@ -95,13 +95,12 @@ function highlightMatchingTeamMembers() {
     });
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
     // Only allow 3 checkboxes (the team) to be checked
     $("input.team-checkbox").change(function () {
         let maxChecked = 3;
         let checkedChecks = document.querySelectorAll(".team-checkbox:checked");
-        if(checkedChecks.length >= maxChecked + 1)
-        {
+        if (checkedChecks.length >= maxChecked + 1) {
             this.checked = false;
             return;
         }


### PR DESCRIPTION
- Highlights selected team members match up results
- Additionally provides user with confirmation that copy has been successful on all pages that use the function
- On Back to main Buddy, it will only return actively selected team member, & additionally last opponents if a full team has been selected
- Refactors creation of params to shared.js, wrapper provided for index to add sets, & optional fields to include these/enable the path (/? vs /teambuider?)